### PR TITLE
Upgrade packaging lib to 15.0

### DIFF
--- a/pkg_resources/_vendor/packaging/__about__.py
+++ b/pkg_resources/_vendor/packaging/__about__.py
@@ -22,7 +22,7 @@ __title__ = "packaging"
 __summary__ = "Core utilities for Python packages"
 __uri__ = "https://github.com/pypa/packaging"
 
-__version__ = "14.5"
+__version__ = "15.0"
 
 __author__ = "Donald Stufft"
 __email__ = "donald@stufft.io"

--- a/pkg_resources/_vendor/packaging/version.py
+++ b/pkg_resources/_vendor/packaging/version.py
@@ -96,11 +96,19 @@ class LegacyVersion(_BaseVersion):
         return self._version
 
     @property
+    def base_version(self):
+        return self._version
+
+    @property
     def local(self):
         return None
 
     @property
     def is_prerelease(self):
+        return False
+
+    @property
+    def is_postrelease(self):
         return False
 
 
@@ -270,6 +278,19 @@ class Version(_BaseVersion):
         return str(self).split("+", 1)[0]
 
     @property
+    def base_version(self):
+        parts = []
+
+        # Epoch
+        if self._version.epoch != 0:
+            parts.append("{0}!".format(self._version.epoch))
+
+        # Release segment
+        parts.append(".".join(str(x) for x in self._version.release))
+
+        return "".join(parts)
+
+    @property
     def local(self):
         version_string = str(self)
         if "+" in version_string:
@@ -278,6 +299,10 @@ class Version(_BaseVersion):
     @property
     def is_prerelease(self):
         return bool(self._version.dev or self._version.pre)
+
+    @property
+    def is_postrelease(self):
+        return bool(self._version.post)
 
 
 def _parse_letter_version(letter, number):

--- a/pkg_resources/_vendor/vendored.txt
+++ b/pkg_resources/_vendor/vendored.txt
@@ -1,1 +1,1 @@
-packaging==14.5
+packaging==15.0


### PR DESCRIPTION
This contains the updates to PEP 440 so that ``>1.7`` **does not** exclude ``1.7.1`` but **does** exclude ``1.7.0`` and ``1.7.0.post1``. See: https://github.com/pypa/interoperability-peps/pull/3 for more details.