### PR TITLE
Fix tox settings so they work

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,7 @@
 [tox]
 envlist = py26,py27,py31,py32,py33,py34
 [testenv]
-deps=pytest
-commands=py.test {posargs}
+deps=
+    pytest
+    mock
+commands=py.test setuptools {posargs}


### PR DESCRIPTION
Update the dependency list to include the mock package.

Update the way py.test is called to only scan the setuptools directory,
to avoid scanning all of the packages installed in .tox and other
temporary directories.