### PR TITLE
Add configurable script_writer parameter

### DIFF
--- a/setuptools/command/install_scripts.py
+++ b/setuptools/command/install_scripts.py
@@ -8,9 +8,13 @@ from pkg_resources import Distribution, PathMetadata, ensure_directory
 class install_scripts(orig.install_scripts):
     """Do normal script install, plus any egg_info wrapper scripts"""
 
+    user_options = orig.install_scripts.user_options + [
+        ('script-writer=', None, 'python path to a ScriptWriter class'),
+    ]
     def initialize_options(self):
         orig.install_scripts.initialize_options(self)
         self.no_ep = False
+        self.script_writer = None
 
     def run(self):
         import setuptools.command.easy_install as ei
@@ -38,7 +42,7 @@ class install_scripts(orig.install_scripts):
             exec_param = "python.exe"
             writer = ei.WindowsScriptWriter
         # resolve the writer to the environment
-        writer = writer.best()
+        writer = writer.best(self.script_writer)
         cmd = writer.command_spec_class.best().from_param(exec_param)
         for args in writer.get_args(dist, cmd.as_header()):
             self.write_script(*args)


### PR DESCRIPTION
Some folks, like OpenStack/pbr, override the template of the generated
console scripts. Enable that via a config option to avoid monkeypatching
the internals of setuptools.