### PR TITLE
Add support for python_platform_implementation environment marker

### DIFF
--- a/pkg_resources/__init__.py
+++ b/pkg_resources/__init__.py
@@ -1403,6 +1403,7 @@ class MarkerEvaluation(object):
         'python_version': lambda: platform.python_version()[:3],
         'platform_version': platform.version,
         'platform_machine': platform.machine,
+        'platform_python_implementation': platform.python_implementation,
         'python_implementation': platform.python_implementation,
     }
 

--- a/pkg_resources/api_tests.txt
+++ b/pkg_resources/api_tests.txt
@@ -420,3 +420,6 @@ Environment Markers
 
     >>> em("python_version > '2.5'")
     True
+
+    >>> im("platform_python_implementation=='CPython'")
+    False


### PR DESCRIPTION
This patch adds support for the 'python_platform_implementation' environment marker as defined by [PEP-0426](https://www.python.org/dev/peps/pep-0426/#environment-markers).

This is the easier half of [issue #387](https://bitbucket.org/pypa/setuptools/issues/387).