### PR TITLE
FreeBSD: Add root certificate from ca_root_nss.

### DIFF
--- a/setuptools/ssl_support.py
+++ b/setuptools/ssl_support.py
@@ -25,6 +25,7 @@ cert_paths = """
 /usr/local/share/certs/ca-root.crt
 /etc/ssl/cert.pem
 /System/Library/OpenSSL/certs/cert.pem
+/usr/local/share/certs/ca-root-nss.crt
 """.strip().split()
 
 


### PR DESCRIPTION
On FreeBSD root certificates from certificate authorities included in the
Mozilla NSS library are provided by the ca_root_nss package:

jcigar@frodon:~/ > pkg info -l ca_root_nss-3.21
ca_root_nss-3.21:
    /usr/local/etc/ssl/cert.pem.sample
    /usr/local/openssl/cert.pem.sample
    /usr/local/share/certs/ca-root-nss.crt
    /usr/local/share/licenses/ca_root_nss-3.21/LICENSE
    /usr/local/share/licenses/ca_root_nss-3.21/MPL
    /usr/local/share/licenses/ca_root_nss-3.21/catalog.mk

On some machines there is no symbolic link (/etc/ssl/cert.pem) installed